### PR TITLE
Use `single` instead of `page` for pages

### DIFF
--- a/inc/class-emitter.php
+++ b/inc/class-emitter.php
@@ -49,7 +49,7 @@ class Emitter {
 			}
 		}
 
-		if ( is_single() ) {
+		if ( is_single() || is_page() ) {
 			$keys[] = 'single';
 			if ( is_attachment() ) {
 				$keys[] = 'attachment';
@@ -67,8 +67,6 @@ class Emitter {
 					$keys[] = 'term-' . $term_id;
 				}
 			}
-		} elseif ( is_page() ) {
-			$keys[] = 'page';
 		}
 
 		$keys = array_unique( $keys );

--- a/tests/test-emitter.php
+++ b/tests/test-emitter.php
@@ -29,7 +29,7 @@ class Test_Emitter extends Pantheon_Integrated_CDN_Testcase {
 	public function test_single_page() {
 		$this->go_to( get_permalink( $this->page_id1 ) );
 		$this->assertArrayValues( array(
-			'page',
+			'single',
 			'post-' . $this->page_id1,
 			'user-' . $this->user_id1,
 		), Emitter::get_surrogate_keys() );


### PR DESCRIPTION
This makes pages more consistent with custom post types