### PR TITLE
Emit `term-<id>` surrogate keys for all terms assigned to a post

### DIFF
--- a/inc/class-emitter.php
+++ b/inc/class-emitter.php
@@ -46,10 +46,20 @@ class Emitter {
 				if ( post_type_supports( $p->post_type, 'author' ) ) {
 					$keys[] = 'user-' . $p->post_author;
 				}
+				if ( $wp_query->is_singular() || $wp_query->is_page() ) {
+					foreach ( get_object_taxonomies( $p ) as $tax ) {
+						$terms = get_the_terms( $p->ID, $tax );
+						if ( $terms && ! is_wp_error( $terms ) ) {
+							foreach ( $terms as $t ) {
+								$keys[] = 'term-' . $t->term_id;
+							}
+						}
+					}
+				}
 			}
 		}
 
-		if ( is_single() || is_page() ) {
+		if ( is_singular() || is_page() ) {
 			$keys[] = 'single';
 			if ( is_attachment() ) {
 				$keys[] = 'attachment';

--- a/tests/class-pantheon-integrated-cdn-testcase.php
+++ b/tests/class-pantheon-integrated-cdn-testcase.php
@@ -15,6 +15,7 @@ class Pantheon_Integrated_CDN_Testcase extends WP_UnitTestCase {
 
 		$this->tag_id1 = $this->factory->tag->create();
 		$this->tag_id2 = $this->factory->tag->create();
+		$this->category_id1 = 1; // default 'uncategorized'
 		$this->category_id2 = $this->factory->category->create();
 
 		$this->post_id1 = $this->factory->post->create( array(

--- a/tests/test-emitter.php
+++ b/tests/test-emitter.php
@@ -23,6 +23,7 @@ class Test_Emitter extends Pantheon_Integrated_CDN_Testcase {
 			'single',
 			'post-' . $this->post_id2,
 			'user-' . $this->user_id2,
+			'term-' . $this->category_id1,
 		), Emitter::get_surrogate_keys() );
 	}
 


### PR DESCRIPTION
When a term is updated, then any posts it is assigned to should be
flushed. However, to prevent tons of surrogate keys on archives, we
should only emit this key on the single post view.