### PR TITLE
Gitignore `composer.lock` and `vendor/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .DS_Store
+composer.lock
 Thumbs.db
 wp-cli.local.yml
 node_modules/
+vendor/


### PR DESCRIPTION
Composer dependencies aren't relevant to the build aspect of this
project.