### PR TITLE
Introduce `archive-user-<id>` surrogate key

### DIFF
--- a/inc/class-emitter.php
+++ b/inc/class-emitter.php
@@ -82,10 +82,12 @@ class Emitter {
 				$keys[] = 'post-type-archive';
 			} elseif ( is_author() ) {
 				if ( $user_id = get_queried_object_id() ) {
+					$keys[] = 'archive-user-' . $user_id;
 					$keys[] = 'user-' . $user_id;
 				}
 			} elseif ( is_category() || is_tag() || is_tax() ) {
 				if ( $term_id = get_queried_object_id() ) {
+					$keys[] = 'archive-term-' . $term_id;
 					$keys[] = 'term-' . $term_id;
 				}
 			}

--- a/inc/class-purger.php
+++ b/inc/class-purger.php
@@ -38,8 +38,8 @@ class Purger {
 			'post-' . $post_id,
 		);
 		$post = get_post( $post_id );
-		if ( $post ) {
-			$keys[] = 'user-' . $post->post_author;
+		if ( $post && post_type_supports( $post->post_type, 'author' ) ) {
+			$keys[] = 'archive-user-' . $post->post_author;
 		}
 		self::clear_keys( $keys );
 	}

--- a/tests/phpunit/test-emitter.php
+++ b/tests/phpunit/test-emitter.php
@@ -72,8 +72,9 @@ class Test_Emitter extends Pantheon_Integrated_CDN_Testcase {
 		$this->go_to( get_author_posts_url( $this->user_id1 ) );
 		$this->assertArrayValues( array(
 			'archive',
-			'post-' . $this->post_id1,
+			'archive-user-' . $this->user_id1,
 			'user-' . $this->user_id1,
+			'post-' . $this->post_id1,
 		), Emitter::get_surrogate_keys() );
 	}
 
@@ -84,6 +85,7 @@ class Test_Emitter extends Pantheon_Integrated_CDN_Testcase {
 		$this->go_to( get_author_posts_url( $this->user_id3 ) );
 		$this->assertArrayValues( array(
 			'archive',
+			'archive-user-' . $this->user_id3,
 			'user-' . $this->user_id3,
 		), Emitter::get_surrogate_keys() );
 	}
@@ -95,6 +97,7 @@ class Test_Emitter extends Pantheon_Integrated_CDN_Testcase {
 		$this->go_to( get_term_link( $this->tag_id2 ) );
 		$this->assertArrayValues( array(
 			'archive',
+			'archive-term-' . $this->tag_id2,
 			'term-' . $this->tag_id2,
 			'post-' . $this->post_id1,
 			'user-' . $this->user_id1,
@@ -108,6 +111,7 @@ class Test_Emitter extends Pantheon_Integrated_CDN_Testcase {
 		$this->go_to( get_term_link( $this->tag_id1 ) );
 		$this->assertArrayValues( array(
 			'archive',
+			'archive-term-' . $this->tag_id1,
 			'term-' . $this->tag_id1,
 		), Emitter::get_surrogate_keys() );
 	}
@@ -119,6 +123,7 @@ class Test_Emitter extends Pantheon_Integrated_CDN_Testcase {
 		$this->go_to( get_term_link( $this->product_category_id1 ) );
 		$this->assertArrayValues( array(
 			'archive',
+			'archive-term-' . $this->product_category_id1,
 			'term-' . $this->product_category_id1,
 			'post-' . $this->product_id2,
 		), Emitter::get_surrogate_keys() );
@@ -131,6 +136,7 @@ class Test_Emitter extends Pantheon_Integrated_CDN_Testcase {
 		$this->go_to( get_term_link( $this->product_category_id3 ) );
 		$this->assertArrayValues( array(
 			'archive',
+			'archive-term-' . $this->product_category_id3,
 			'term-' . $this->product_category_id3,
 		), Emitter::get_surrogate_keys() );
 	}

--- a/tests/phpunit/test-purger.php
+++ b/tests/phpunit/test-purger.php
@@ -19,7 +19,7 @@ class Test_Purger extends Pantheon_Integrated_CDN_Testcase {
 			'home',
 			'front',
 			'post-' . $this->post_id1,
-			'user-' . $this->user_id1,
+			'archive-user-' . $this->user_id1,
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
@@ -28,7 +28,6 @@ class Test_Purger extends Pantheon_Integrated_CDN_Testcase {
 			'/2016/10/14/',
 			'/2016/10/14/first-post/',
 			'/author/first-user/',
-			'/first-page/',
 			'/category/uncategorized/',
 			'/tag/second-tag/',
 		) );
@@ -43,18 +42,12 @@ class Test_Purger extends Pantheon_Integrated_CDN_Testcase {
 			'home',
 			'front',
 			'post-' . $this->page_id1,
-			'user-' . $this->user_id1,
+			'archive-user-' . $this->user_id1,
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
-			'/2016/',
-			'/2016/10/',
-			'/2016/10/14/',
-			'/2016/10/14/first-post/',
 			'/author/first-user/',
 			'/first-page/',
-			'/category/uncategorized/',
-			'/tag/second-tag/',
 		) );
 	}
 
@@ -67,18 +60,9 @@ class Test_Purger extends Pantheon_Integrated_CDN_Testcase {
 			'home',
 			'front',
 			'post-' . $this->product_id1,
-			'user-' . $this->user_id1,
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
-			'/2016/',
-			'/2016/10/',
-			'/2016/10/14/',
-			'/2016/10/14/first-post/',
-			'/author/first-user/',
-			'/first-page/',
-			'/category/uncategorized/',
-			'/tag/second-tag/',
 			'/product-category/second-product-category/',
 			'/product/first-product/',
 			'/products/',


### PR DESCRIPTION
Adding a key specific to author archives permits purging the author
archive without purging all posts authored by the author.

See #28