### PR TITLE
Persist purged keys through the entire test

### DIFF
--- a/tests/phpunit/class-pantheon-integrated-cdn-testcase.php
+++ b/tests/phpunit/class-pantheon-integrated-cdn-testcase.php
@@ -150,7 +150,7 @@ class Pantheon_Integrated_CDN_Testcase extends WP_UnitTestCase {
 	 * @param array $keys Surrogate keys being cleared.
 	 */
 	public function action_pantheon_wp_clear_edge_keys( $keys ) {
-		$this->cleared_keys = $keys;
+		$this->cleared_keys = array_merge( $this->cleared_keys, $keys );
 	}
 
 	/**

--- a/tests/phpunit/test-purger.php
+++ b/tests/phpunit/test-purger.php
@@ -81,6 +81,8 @@ class Test_Purger extends Pantheon_Integrated_CDN_Testcase {
 			'home',
 			'front',
 			'post-' . $this->post_id1,
+			'term-' . $this->category_id1,
+			'term-' . $this->tag_id2,
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
@@ -88,6 +90,8 @@ class Test_Purger extends Pantheon_Integrated_CDN_Testcase {
 			'/2016/10/',
 			'/2016/10/14/',
 			'/2016/10/14/first-post/',
+			'/2016/10/14/second-post/',
+			'/2016/10/15/third-post/',
 			'/author/first-user/',
 			'/category/uncategorized/',
 			'/tag/second-tag/',


### PR DESCRIPTION
Doing so exposes the fact that `clean_term_cache` is called when a post
is updated, which unexpectedly purges cache for all posts with the term
assigned.

See #28