### PR TITLE
Only purge related surrogate keys when interpreting a higher-level event

### DIFF
--- a/inc/class-purger.php
+++ b/inc/class-purger.php
@@ -13,11 +13,98 @@ namespace Pantheon_Integrated_CDN;
 class Purger {
 
 	/**
-	 * Purge a variety of surrogate keys when a post is modified.
+	 * Purge surrogate keys associated with a post being updated.
+	 *
+	 * @param integer $post_id ID for the modified post.
+	 */
+	public static function action_wp_insert_post( $post_id ) {
+		self::purge_post_with_related( $post_id );
+	}
+
+	/**
+	 * Purge surrogate keys associated with a post being deleted.
+	 *
+	 * @param integer $post_id ID for the post to be deleted.
+	 */
+	public static function action_before_delete_post( $post_id ) {
+		self::purge_post_with_related( $post_id );
+	}
+
+	/**
+	 * Purge surrogate keys associated with an attachment being deleted.
+	 *
+	 * @param integer $post_id ID for the modified attachment.
+	 */
+	public static function action_delete_attachment( $post_id ) {
+		self::purge_post_with_related( $post_id );
+	}
+
+	/**
+	 * Purge the post's surrogate key when the post cache is cleared.
 	 *
 	 * @param integer $post_id ID for the modified post.
 	 */
 	public static function action_clean_post_cache( $post_id ) {
+		$type = get_post_type( $post_id );
+		// Ignore revisions, which aren't ever displayed on the site.
+		if ( $type && 'revision' === $type ) {
+			return;
+		}
+		pantheon_wp_clear_edge_keys( array( 'post-' . $post_id ) );
+	}
+
+	/**
+	 * Purge surrogate keys associated with a term being created.
+	 *
+	 * @param integer $term_id ID for the created term.
+	 */
+	public static function action_created_term( $term_id ) {
+		self::purge_term( $term_id );
+	}
+
+	/**
+	 * Purge surrogate keys associated with a term being edited.
+	 *
+	 * @param integer $term_id ID for the edited term.
+	 */
+	public static function action_edited_term( $term_id ) {
+		self::purge_term( $term_id );
+	}
+
+	/**
+	 * Purge surrogate keys associated with a term being deleted.
+	 *
+	 * @param integer $term_id ID for the deleted term.
+	 */
+	public static function action_delete_term( $term_id ) {
+		self::purge_term( $term_id );
+	}
+
+	/**
+	 * Purge the term's archive surrogate key when the term is modified.
+	 *
+	 * @param integer $term_ids One or more IDs of modified terms.
+	 */
+	public static function action_clean_term_cache( $term_ids ) {
+		$keys = array();
+		$term_ids = is_array( $term_ids ) ? $term_ids : array( $term_id );
+		foreach ( $term_ids as $term_id ) {
+			$keys[] = 'archive-term-' . $term_id;
+		}
+		pantheon_wp_clear_edge_keys( $keys );
+	}
+
+	/**
+	 * Purge the surrogate keys associated with a post being modified.
+	 *
+	 * @param integer $post_id ID for the modified post.
+	 */
+	private static function purge_post_with_related( $post_id ) {
+		$type = get_post_type( $post_id );
+		// Ignore revisions, which aren't ever displayed on the site.
+		if ( $type && 'revision' === $type ) {
+			return;
+		}
 		$keys = array(
 			'home',
 			'front',
@@ -42,18 +129,14 @@ class Purger {
 	}
 
 	/**
-	 * Purge a variety of surrogate keys when a term is modified.
+	 * Purge the surrogate keys associated with a term being modified.
 	 *
-	 * @param integer $term_ids One or more IDs of modified terms.
+	 * @param integer $term_id ID for the modified term.
 	 */
-	public static function action_clean_term_cache( $term_ids ) {
-		$keys = array();
-		$term_ids = is_array( $term_ids ) ? $term_ids : array( $term_id );
-		foreach ( $term_ids as $term_id ) {
-			$keys[] = 'term-' . $term_id;
-		}
-		pantheon_wp_clear_edge_keys( $keys );
+	private static function purge_term( $term_id ) {
+		pantheon_wp_clear_edge_keys( array( 'term-' . $term_id ) );
 	}
+
 
 	/**
 	 * Purge a variety of surrogate keys when a user is modified.
@@ -62,7 +145,7 @@ class Purger {
 	 */
 	public static function action_clean_user_cache( $user_id ) {
 		$keys = array(
-			'user-' . $user_id,
+			'archive-user-' . $user_id,
 		);
 		pantheon_wp_clear_edge_keys( $keys );
 	}

--- a/pantheon-integrated-cdn.php
+++ b/pantheon-integrated-cdn.php
@@ -96,8 +96,14 @@ add_action( 'pantheon_cache_settings_page_bottom', array( 'Pantheon_Integrated_C
 add_filter( 'wp', array( 'Pantheon_Integrated_CDN\Emitter', 'action_wp' ) );
 
 /**
- * Clears surrogate tags when object caches are cleared.
+ * Clears surrogate tags when various modification behaviors are performed.
  */
+add_action( 'wp_insert_post', array( 'Pantheon_Integrated_CDN\Purger', 'action_wp_insert_post' ) );
+add_action( 'before_delete_post', array( 'Pantheon_Integrated_CDN\Purger', 'action_before_delete_post' ) );
+add_action( 'delete_attachment', array( 'Pantheon_Integrated_CDN\Purger', 'action_delete_attachment' ) );
 add_action( 'clean_post_cache', array( 'Pantheon_Integrated_CDN\Purger', 'action_clean_post_cache' ) );
+add_action( 'created_term', array( 'Pantheon_Integrated_CDN\Purger', 'action_created_term' ) );
+add_action( 'edited_term', array( 'Pantheon_Integrated_CDN\Purger', 'action_edited_term' ) );
+add_action( 'delete_term', array( 'Pantheon_Integrated_CDN\Purger', 'action_delete_term' ) );
 add_action( 'clean_term_cache', array( 'Pantheon_Integrated_CDN\Purger', 'action_clean_term_cache' ) );
 add_action( 'clean_user_cache', array( 'Pantheon_Integrated_CDN\Purger', 'action_clean_user_cache' ) );

--- a/tests/phpunit/class-pantheon-integrated-cdn-testcase.php
+++ b/tests/phpunit/class-pantheon-integrated-cdn-testcase.php
@@ -172,8 +172,8 @@ class Pantheon_Integrated_CDN_Testcase extends WP_UnitTestCase {
 			'taxonomy'       => array( 'post_tag', 'category', 'product_category' ),
 			'hide_empty'     => false,
 		) );
-		foreach ( $terms as $term_id ) {
-			$views[] = get_term_link( $term_id );
+		foreach ( $terms as $term ) {
+			$views[] = get_term_link( $term->term_id, $term->taxonomy );
 		}
 		$views = array_unique( $views );
 		foreach ( $views as $view ) {

--- a/tests/phpunit/class-pantheon-integrated-cdn-testcase.php
+++ b/tests/phpunit/class-pantheon-integrated-cdn-testcase.php
@@ -172,8 +172,8 @@ class Pantheon_Integrated_CDN_Testcase extends WP_UnitTestCase {
 			'taxonomy'       => array( 'post_tag', 'category', 'product_category' ),
 			'hide_empty'     => false,
 		) );
-		foreach ( $terms as $term ) {
-			$views[] = get_term_link( $term->term_id, $term->taxonomy );
+		foreach ( $terms as $term_id ) {
+			$views[] = get_term_link( $term_id );
 		}
 		$views = array_unique( $views );
 		foreach ( $views as $view ) {

--- a/tests/phpunit/class-pantheon-integrated-cdn-testcase.php
+++ b/tests/phpunit/class-pantheon-integrated-cdn-testcase.php
@@ -207,7 +207,7 @@ class Pantheon_Integrated_CDN_Testcase extends WP_UnitTestCase {
 	 * @param array $expected Surrogate keys expected to be cleared.
 	 */
 	protected function assertClearedKeys( $expected ) {
-		$this->assertArrayValues( $expected, $this->cleared_keys );
+		$this->assertArrayValues( $expected, array_unique( $this->cleared_keys ) );
 	}
 
 	/**

--- a/tests/phpunit/class-pantheon-integrated-cdn-testcase.php
+++ b/tests/phpunit/class-pantheon-integrated-cdn-testcase.php
@@ -168,12 +168,11 @@ class Pantheon_Integrated_CDN_Testcase extends WP_UnitTestCase {
 		foreach ( $users as $user_id ) {
 			$views[] = get_author_posts_url( $user_id );
 		}
-		$terms = get_terms( array(
-			'taxonomy'       => array( 'post_tag', 'category', 'product_category' ),
+		$terms = get_terms( array( 'post_tag', 'category', 'product_category' ), array(
 			'hide_empty'     => false,
 		) );
-		foreach ( $terms as $term_id ) {
-			$views[] = get_term_link( $term_id );
+		foreach ( $terms as $term ) {
+			$views[] = get_term_link( $term );
 		}
 		$views = array_unique( $views );
 		foreach ( $views as $view ) {

--- a/tests/phpunit/class-pantheon-integrated-cdn-testcase.php
+++ b/tests/phpunit/class-pantheon-integrated-cdn-testcase.php
@@ -105,41 +105,7 @@ class Pantheon_Integrated_CDN_Testcase extends WP_UnitTestCase {
 		wp_set_object_terms( $this->product_id2, array( $this->product_category_id1 ), 'product_category' );
 
 		$this->cleared_keys = array();
-
-		// Primes the mapping of views to their surrogate keys.
-		$views = array(
-			home_url( '/' ), // Homepage.
-			get_permalink( $this->post_id1 ), // Single post.
-			get_permalink( $this->post_id2 ), // Single post.
-			get_permalink( $this->post_id3 ), // Single post.
-			get_permalink( $this->page_id1 ), // Single page.
-			get_permalink( $this->product_id1 ), // Single product.
-			get_permalink( $this->product_id2 ), // Single product.
-			get_term_link( $this->tag_id1 ), // Single term.
-			get_term_link( $this->tag_id2 ), // Single term.
-			get_term_link( $this->category_id1 ), // Single term.
-			get_term_link( $this->product_category_id1 ), // Single product category.
-			get_term_link( $this->product_category_id2 ), // Single product category.
-			get_term_link( $this->product_category_id3 ), // Single product category.
-			get_author_posts_url( $this->user_id1 ), // Single author.
-			get_author_posts_url( $this->user_id2 ), // Single author.
-			get_author_posts_url( $this->user_id3 ), // Single author.
-			'/products/', // Product post type archive.
-			'/2016/10/14/', // Day archive with posts.
-			'/2015/10/15/', // Day archive without posts.
-			'/2016/10/', // Month archive with posts.
-			'/2015/10/', // Month archive without posts.
-			'/2016/', // Year archive with posts.
-			'/2015/', // Year archive without posts.
-		);
-		foreach ( $views as $view ) {
-			$path = parse_url( $view, PHP_URL_PATH );
-			if ( $query = parse_url( $view, PHP_URL_QUERY ) ) {
-				$path .= '?' . $query;
-			}
-			$this->go_to( $view );
-			$this->view_surrogate_keys[ $path ] = Emitter::get_surrogate_keys();
-		}
+		$this->setup_view_surrogate_keys();
 
 		add_action( 'pantheon_wp_clear_edge_keys', array( $this, 'action_pantheon_wp_clear_edge_keys' ) );
 	}
@@ -169,6 +135,54 @@ class Pantheon_Integrated_CDN_Testcase extends WP_UnitTestCase {
 		$this->register_custom_types();
 
 		$wp_rewrite->flush_rules();
+	}
+
+	/**
+	 * Primes the mapping of views to their surrogate keys.
+	 */
+	protected function setup_view_surrogate_keys() {
+		// Primes the mapping of views to their surrogate keys.
+		$views = array(
+			home_url( '/' ), // Homepage.
+			'/products/', // Product post type archive.
+			'/2016/10/14/', // Day archive with posts.
+			'/2015/10/15/', // Day archive without posts.
+			'/2016/10/', // Month archive with posts.
+			'/2015/10/', // Month archive without posts.
+			'/2016/', // Year archive with posts.
+			'/2015/', // Year archive without posts.
+		);
+		$posts = get_posts( array(
+			'fields'         => 'ids',
+			'post_type'      => 'any',
+			'post_status'    => 'any',
+			'posts_per_page' => -1,
+		) );
+		foreach ( $posts as $post_id ) {
+			$views[] = get_permalink( $post_id );
+		}
+		$users = get_users( array(
+			'fields'         => 'ids',
+		) );
+		foreach ( $users as $user_id ) {
+			$views[] = get_author_posts_url( $user_id );
+		}
+		$terms = get_terms( array(
+			'taxonomy'       => array( 'post_tag', 'category', 'product_category' ),
+			'hide_empty'     => false,
+		) );
+		foreach ( $terms as $term_id ) {
+			$views[] = get_term_link( $term_id );
+		}
+		$views = array_unique( $views );
+		foreach ( $views as $view ) {
+			$path = parse_url( $view, PHP_URL_PATH );
+			if ( $query = parse_url( $view, PHP_URL_QUERY ) ) {
+				$path .= '?' . $query;
+			}
+			$this->go_to( $view );
+			$this->view_surrogate_keys[ $path ] = Emitter::get_surrogate_keys();
+		}
 	}
 
 	/**

--- a/tests/phpunit/class-pantheon-integrated-cdn-testcase.php
+++ b/tests/phpunit/class-pantheon-integrated-cdn-testcase.php
@@ -141,6 +141,7 @@ class Pantheon_Integrated_CDN_Testcase extends WP_UnitTestCase {
 	 * Primes the mapping of views to their surrogate keys.
 	 */
 	protected function setup_view_surrogate_keys() {
+		$this->view_surrogate_keys = array();
 		// Primes the mapping of views to their surrogate keys.
 		$views = array(
 			home_url( '/' ), // Homepage.


### PR DESCRIPTION
Because `wp_insert_post()` calls `clean_term_cache`, it caused an update to
Post A to purge the cache of Post B when they shared a common term. By
moving the related surrogate key purging to higher-level events, we can
mitigate unnecessary noisiness caused by `clean_*_cache`

See #28