### PR TITLE
Deprecate `archive-*` surrogate key in favor of `post-*`

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,47 +74,57 @@ Need a bit more power? Here are two additional helper functions you can use:
 
 **Home `/`**
 
-* Emits surrogate keys: `home`, `front`, `post-<id>` (all posts in main query), `user-<id>` (all authors of posts in the main query)
+* Emits surrogate keys: `home`, `front`, `post-<id>` (all posts in main query)
 
 **Single post `/2016/10/14/surrogate-keys/`**
 
-* Emits surrogate keys: `single`, `post-<id>`, `user-<id>`, `term-<id>` (all terms assigned to post)
+* Emits surrogate keys: `single`, `post-<id>`, `post-user-<id>`, `post-term-<id>` (all terms assigned to post)
 
 **Author archive `/author/pantheon/`**
 
-* Emits surrogate keys: `archive`, `archive-user-<id>`, `user-<id>`, `post-<id>` (all posts in main query)
+* Emits surrogate keys: `archive`, `user-<id>`, `post-<id>` (all posts in main query)
 
 **Term archive `/tag/cdn/`**
 
-* Emits surrogate keys: `archive`, `archive-term-<id>`, `term-<id>`, `post-<id>` (all posts in main query), `user-<id>` (all authors of posts in the main query)
+* Emits surrogate keys: `archive`, `term-<id>`, `post-<id>` (all posts in main query)
 
 **Day archive `/2016/10/14/`**
 
-* Emits surrogate keys: `archive`, `date`, `post-<id>` (all posts in main query), `user-<id>` (all authors of posts in the main query)
+* Emits surrogate keys: `archive`, `date`, `post-<id>` (all posts in main query)
 
 **Month archive `/2016/10/`**
 
-* Emits surrogate keys: `archive`, `date`, `post-<id>` (all posts in main query), `user-<id>` (all authors of posts in the main query)
+* Emits surrogate keys: `archive`, `date`, `post-<id>` (all posts in main query)
 
 **Year archive `/2016/`**
 
-* Emits surrogate keys: `archive`, `date`, `post-<id>` (all posts in main query), `user-<id>` (all authors of posts in the main query)
+* Emits surrogate keys: `archive`, `date`, `post-<id>` (all posts in main query)
 
 **Search `/?s=<search>`**
 
-* Emits surrogate keys: `search`, either `search-results` or `search-no-results`, `post-<id>` (all posts in main query), `user-<id>` (all authors of posts in the main query)
+* Emits surrogate keys: `search`, either `search-results` or `search-no-results`, `post-<id>` (all posts in main query)
 
 ### Purge Events ###
 
+**wp_insert_post / before_delete_post / delete_attachment**
+
+* Purges surrogate keys: `home`, `front`, `post-<id>`, `user-<id>`, `term-<id>`
+* Affected views: homepage, single post, any archive where post displays, author archive, term archive
+
 **clean_post_cache**
 
-* Purges surrogate keys: `home`, `front`, `post-<id>`, `archive-user-<id>`, `archive-term-<id>`
-* Affected views: homepage, single post, any archive where post displays, author archive, term archive
+* Purges surrogate keys: `post-<id>`
+* Affected views: single post
+
+**created_term / edited_term / delete_term**
+
+* Purges surrogate keys: `term-<id>`, `post-term-<id>`
+* Affected views: term archive, any post where the term is assigned
 
 **clean_term_cache**
 
 * Purges surrogate keys: `term-<id>`
-* Affected views: term archive, any post where the term is assigned
+* Affected views: term archive
 
 **clean_user_cache**
 

--- a/inc/class-emitter.php
+++ b/inc/class-emitter.php
@@ -60,15 +60,15 @@ class Emitter {
 		if ( ! empty( $wp_query->posts ) ) {
 			foreach ( $wp_query->posts as $p ) {
 				$keys[] = 'post-' . $p->ID;
-				if ( post_type_supports( $p->post_type, 'author' ) ) {
-					$keys[] = 'user-' . $p->post_author;
-				}
 				if ( $wp_query->is_singular() || $wp_query->is_page() ) {
+					if ( post_type_supports( $p->post_type, 'author' ) ) {
+						$keys[] = 'post-user-' . $p->post_author;
+					}
 					foreach ( get_object_taxonomies( $p ) as $tax ) {
 						$terms = get_the_terms( $p->ID, $tax );
 						if ( $terms && ! is_wp_error( $terms ) ) {
 							foreach ( $terms as $t ) {
-								$keys[] = 'term-' . $t->term_id;
+								$keys[] = 'post-term-' . $t->term_id;
 							}
 						}
 					}
@@ -87,12 +87,10 @@ class Emitter {
 				$keys[] = 'post-type-archive';
 			} elseif ( is_author() ) {
 				if ( $user_id = get_queried_object_id() ) {
-					$keys[] = 'archive-user-' . $user_id;
 					$keys[] = 'user-' . $user_id;
 				}
 			} elseif ( is_category() || is_tag() || is_tax() ) {
 				if ( $term_id = get_queried_object_id() ) {
-					$keys[] = 'archive-term-' . $term_id;
 					$keys[] = 'term-' . $term_id;
 				}
 			}

--- a/inc/class-purger.php
+++ b/inc/class-purger.php
@@ -89,7 +89,7 @@ class Purger {
 		$keys = array();
 		$term_ids = is_array( $term_ids ) ? $term_ids : array( $term_id );
 		foreach ( $term_ids as $term_id ) {
-			$keys[] = 'archive-term-' . $term_id;
+			$keys[] = 'term-' . $term_id;
 		}
 		pantheon_wp_clear_edge_keys( $keys );
 	}
@@ -113,14 +113,14 @@ class Purger {
 		$post = get_post( $post_id );
 		if ( $post ) {
 			if ( post_type_supports( $post->post_type, 'author' ) ) {
-				$keys[] = 'archive-user-' . $post->post_author;
+				$keys[] = 'user-' . $post->post_author;
 			}
 			$taxonomies = wp_list_filter( get_object_taxonomies( $post->post_type, 'objects' ), array( 'public' => true ) );
 			foreach ( $taxonomies as $taxonomy ) {
 				$terms = get_the_terms( $post, $taxonomy->name );
 				if ( $terms ) {
 					foreach ( $terms as $term ) {
-						$keys[] = 'archive-term-' . $term->term_id;
+						$keys[] = 'term-' . $term->term_id;
 					}
 				}
 			}
@@ -134,7 +134,7 @@ class Purger {
 	 * @param integer $term_id ID for the modified term.
 	 */
 	private static function purge_term( $term_id ) {
-		pantheon_wp_clear_edge_keys( array( 'term-' . $term_id ) );
+		pantheon_wp_clear_edge_keys( array( 'term-' . $term_id, 'post-term-' . $term_id ) );
 	}
 
 
@@ -145,7 +145,7 @@ class Purger {
 	 */
 	public static function action_clean_user_cache( $user_id ) {
 		$keys = array(
-			'archive-user-' . $user_id,
+			'user-' . $user_id,
 		);
 		pantheon_wp_clear_edge_keys( $keys );
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -74,47 +74,57 @@ Need a bit more power? Here are two additional helper functions you can use:
 
 **Home `/`**
 
-* Emits surrogate keys: `home`, `front`, `post-<id>` (all posts in main query), `user-<id>` (all authors of posts in the main query)
+* Emits surrogate keys: `home`, `front`, `post-<id>` (all posts in main query)
 
 **Single post `/2016/10/14/surrogate-keys/`**
 
-* Emits surrogate keys: `single`, `post-<id>`, `user-<id>`, `term-<id>` (all terms assigned to post)
+* Emits surrogate keys: `single`, `post-<id>`, `post-user-<id>`, `post-term-<id>` (all terms assigned to post)
 
 **Author archive `/author/pantheon/`**
 
-* Emits surrogate keys: `archive`, `archive-user-<id>`, `user-<id>`, `post-<id>` (all posts in main query)
+* Emits surrogate keys: `archive`, `user-<id>`, `post-<id>` (all posts in main query)
 
 **Term archive `/tag/cdn/`**
 
-* Emits surrogate keys: `archive`, `archive-term-<id>`, `term-<id>`, `post-<id>` (all posts in main query), `user-<id>` (all authors of posts in the main query)
+* Emits surrogate keys: `archive`, `term-<id>`, `post-<id>` (all posts in main query)
 
 **Day archive `/2016/10/14/`**
 
-* Emits surrogate keys: `archive`, `date`, `post-<id>` (all posts in main query), `user-<id>` (all authors of posts in the main query)
+* Emits surrogate keys: `archive`, `date`, `post-<id>` (all posts in main query)
 
 **Month archive `/2016/10/`**
 
-* Emits surrogate keys: `archive`, `date`, `post-<id>` (all posts in main query), `user-<id>` (all authors of posts in the main query)
+* Emits surrogate keys: `archive`, `date`, `post-<id>` (all posts in main query)
 
 **Year archive `/2016/`**
 
-* Emits surrogate keys: `archive`, `date`, `post-<id>` (all posts in main query), `user-<id>` (all authors of posts in the main query)
+* Emits surrogate keys: `archive`, `date`, `post-<id>` (all posts in main query)
 
 **Search `/?s=<search>`**
 
-* Emits surrogate keys: `search`, either `search-results` or `search-no-results`, `post-<id>` (all posts in main query), `user-<id>` (all authors of posts in the main query)
+* Emits surrogate keys: `search`, either `search-results` or `search-no-results`, `post-<id>` (all posts in main query)
 
 = Purge Events =
 
+**wp_insert_post / before_delete_post / delete_attachment**
+
+* Purges surrogate keys: `home`, `front`, `post-<id>`, `user-<id>`, `term-<id>`
+* Affected views: homepage, single post, any archive where post displays, author archive, term archive
+
 **clean_post_cache**
 
-* Purges surrogate keys: `home`, `front`, `post-<id>`, `archive-user-<id>`, `archive-term-<id>`
-* Affected views: homepage, single post, any archive where post displays, author archive, term archive
+* Purges surrogate keys: `post-<id>`
+* Affected views: single post
+
+**created_term / edited_term / delete_term**
+
+* Purges surrogate keys: `term-<id>`, `post-term-<id>`
+* Affected views: term archive, any post where the term is assigned
 
 **clean_term_cache**
 
 * Purges surrogate keys: `term-<id>`
-* Affected views: term archive, any post where the term is assigned
+* Affected views: term archive
 
 **clean_user_cache**
 

--- a/tests/behat/home.feature
+++ b/tests/behat/home.feature
@@ -2,6 +2,5 @@ Feature: Verify CDN behavior as it pertains to the WordPress homepage
 
   Scenario: Homepage emits correct surrogate keys
     Given I go to "/"
-    Then the response header "Surrogate-Key-Raw" should be "front home post-1"
-    And the response header "Surrogate-Key" should not be ""
-
+    Then the response header "Surrogate-Key" should not be ""
+    And the response header "Surrogate-Key-Raw" should be "front home post-1"

--- a/tests/behat/home.feature
+++ b/tests/behat/home.feature
@@ -2,6 +2,6 @@ Feature: Verify CDN behavior as it pertains to the WordPress homepage
 
   Scenario: Homepage emits correct surrogate keys
     Given I go to "/"
-    Then the response header "Surrogate-Key-Raw" should be "front home post-1 user-1"
+    Then the response header "Surrogate-Key-Raw" should be "front home post-1"
     And the response header "Surrogate-Key" should not be ""
 

--- a/tests/behat/page.feature
+++ b/tests/behat/page.feature
@@ -2,6 +2,6 @@ Feature: Verify CDN behavior as it pertains to a single WordPress page
 
   Scenario: Single page emits correct surrogate keys
     Given I go to "/?p=2"
-    Then the response header "Surrogate-Key-Raw" should be "post-2 user-1 single"
+    Then the response header "Surrogate-Key-Raw" should be "post-2 post-user-1 single"
     And the response header "Surrogate-Key" should not be ""
 

--- a/tests/behat/page.feature
+++ b/tests/behat/page.feature
@@ -2,6 +2,5 @@ Feature: Verify CDN behavior as it pertains to a single WordPress page
 
   Scenario: Single page emits correct surrogate keys
     Given I go to "/?p=2"
-    Then the response header "Surrogate-Key-Raw" should be "post-2 post-user-1 single"
-    And the response header "Surrogate-Key" should not be ""
-
+    Then the response header "Surrogate-Key" should not be ""
+    And the response header "Surrogate-Key-Raw" should be "post-2 post-user-1 single"

--- a/tests/behat/post.feature
+++ b/tests/behat/post.feature
@@ -2,6 +2,6 @@ Feature: Verify CDN behavior as it pertains to a single WordPress post
 
   Scenario: Single post emits correct surrogate keys
     Given I go to "/?p=1"
-    Then the response header "Surrogate-Key-Raw" should be "post-1 user-1 term-1 single"
+    Then the response header "Surrogate-Key-Raw" should be "post-1 post-user-1 post-term-1 single"
     And the response header "Surrogate-Key" should not be ""
 

--- a/tests/behat/post.feature
+++ b/tests/behat/post.feature
@@ -2,6 +2,6 @@ Feature: Verify CDN behavior as it pertains to a single WordPress post
 
   Scenario: Single post emits correct surrogate keys
     Given I go to "/?p=1"
-    Then the response header "Surrogate-Key-Raw" should be "post-1 post-user-1 post-term-1 single"
-    And the response header "Surrogate-Key" should not be ""
+    Then the response header "Surrogate-Key" should not be ""
+    And the response header "Surrogate-Key-Raw" should be "post-1 post-user-1 post-term-1 single"
 

--- a/tests/phpunit/test-emitter.php
+++ b/tests/phpunit/test-emitter.php
@@ -23,8 +23,6 @@ class Test_Emitter extends Pantheon_Integrated_CDN_Testcase {
 			'post-' . $this->post_id1,
 			'post-' . $this->post_id2,
 			'post-' . $this->post_id3,
-			'user-' . $this->user_id1,
-			'user-' . $this->user_id2,
 		), Emitter::get_surrogate_keys() );
 	}
 
@@ -36,8 +34,8 @@ class Test_Emitter extends Pantheon_Integrated_CDN_Testcase {
 		$this->assertArrayValues( array(
 			'single',
 			'post-' . $this->post_id2,
-			'user-' . $this->user_id2,
-			'term-' . $this->category_id1,
+			'post-user-' . $this->user_id2,
+			'post-term-' . $this->category_id1,
 		), Emitter::get_surrogate_keys() );
 	}
 
@@ -49,7 +47,7 @@ class Test_Emitter extends Pantheon_Integrated_CDN_Testcase {
 		$this->assertArrayValues( array(
 			'single',
 			'post-' . $this->page_id1,
-			'user-' . $this->user_id1,
+			'post-user-' . $this->user_id1,
 		), Emitter::get_surrogate_keys() );
 	}
 
@@ -61,7 +59,7 @@ class Test_Emitter extends Pantheon_Integrated_CDN_Testcase {
 		$this->assertArrayValues( array(
 			'single',
 			'post-' . $this->product_id1,
-			'term-' . $this->product_category_id2,
+			'post-term-' . $this->product_category_id2,
 		), Emitter::get_surrogate_keys() );
 	}
 
@@ -72,7 +70,6 @@ class Test_Emitter extends Pantheon_Integrated_CDN_Testcase {
 		$this->go_to( get_author_posts_url( $this->user_id1 ) );
 		$this->assertArrayValues( array(
 			'archive',
-			'archive-user-' . $this->user_id1,
 			'user-' . $this->user_id1,
 			'post-' . $this->post_id1,
 		), Emitter::get_surrogate_keys() );
@@ -85,7 +82,6 @@ class Test_Emitter extends Pantheon_Integrated_CDN_Testcase {
 		$this->go_to( get_author_posts_url( $this->user_id3 ) );
 		$this->assertArrayValues( array(
 			'archive',
-			'archive-user-' . $this->user_id3,
 			'user-' . $this->user_id3,
 		), Emitter::get_surrogate_keys() );
 	}
@@ -97,10 +93,8 @@ class Test_Emitter extends Pantheon_Integrated_CDN_Testcase {
 		$this->go_to( get_term_link( $this->tag_id2 ) );
 		$this->assertArrayValues( array(
 			'archive',
-			'archive-term-' . $this->tag_id2,
 			'term-' . $this->tag_id2,
 			'post-' . $this->post_id1,
-			'user-' . $this->user_id1,
 		), Emitter::get_surrogate_keys() );
 	}
 
@@ -111,7 +105,6 @@ class Test_Emitter extends Pantheon_Integrated_CDN_Testcase {
 		$this->go_to( get_term_link( $this->tag_id1 ) );
 		$this->assertArrayValues( array(
 			'archive',
-			'archive-term-' . $this->tag_id1,
 			'term-' . $this->tag_id1,
 		), Emitter::get_surrogate_keys() );
 	}
@@ -123,7 +116,6 @@ class Test_Emitter extends Pantheon_Integrated_CDN_Testcase {
 		$this->go_to( get_term_link( $this->product_category_id1 ) );
 		$this->assertArrayValues( array(
 			'archive',
-			'archive-term-' . $this->product_category_id1,
 			'term-' . $this->product_category_id1,
 			'post-' . $this->product_id2,
 		), Emitter::get_surrogate_keys() );
@@ -136,7 +128,6 @@ class Test_Emitter extends Pantheon_Integrated_CDN_Testcase {
 		$this->go_to( get_term_link( $this->product_category_id3 ) );
 		$this->assertArrayValues( array(
 			'archive',
-			'archive-term-' . $this->product_category_id3,
 			'term-' . $this->product_category_id3,
 		), Emitter::get_surrogate_keys() );
 	}
@@ -165,8 +156,6 @@ class Test_Emitter extends Pantheon_Integrated_CDN_Testcase {
 			'post-' . $this->post_id1,
 			'post-' . $this->post_id2,
 			'post-' . $this->post_id3,
-			'user-' . $this->user_id1,
-			'user-' . $this->user_id2,
 		), Emitter::get_surrogate_keys() );
 	}
 
@@ -189,8 +178,6 @@ class Test_Emitter extends Pantheon_Integrated_CDN_Testcase {
 			'post-' . $this->post_id1,
 			'post-' . $this->post_id2,
 			'post-' . $this->post_id3,
-			'user-' . $this->user_id1,
-			'user-' . $this->user_id2,
 		), Emitter::get_surrogate_keys() );
 	}
 
@@ -211,7 +198,6 @@ class Test_Emitter extends Pantheon_Integrated_CDN_Testcase {
 			'archive',
 			'date',
 			'post-' . $this->post_id3,
-			'user-' . $this->user_id2,
 		), Emitter::get_surrogate_keys() );
 	}
 
@@ -237,8 +223,6 @@ class Test_Emitter extends Pantheon_Integrated_CDN_Testcase {
 			'post-' . $this->page_id1,
 			'post-' . $this->product_id1,
 			'post-' . $this->product_id2,
-			'user-' . $this->user_id1,
-			'user-' . $this->user_id2,
 		), Emitter::get_surrogate_keys() );
 	}
 

--- a/tests/phpunit/test-purger.php
+++ b/tests/phpunit/test-purger.php
@@ -25,8 +25,8 @@ class Test_Purger extends Pantheon_Integrated_CDN_Testcase {
 			'home',
 			'front',
 			'post-' . $this->post_id4,
-			'archive-user-' . $this->user_id1,
-			'archive-term-' . $this->category_id1,
+			'user-' . $this->user_id1,
+			'term-' . $this->category_id1,
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
@@ -47,9 +47,9 @@ class Test_Purger extends Pantheon_Integrated_CDN_Testcase {
 			'home',
 			'front',
 			'post-' . $this->post_id1,
-			'archive-user-' . $this->user_id1,
-			'archive-term-' . $this->category_id1,
-			'archive-term-' . $this->tag_id2,
+			'user-' . $this->user_id1,
+			'term-' . $this->category_id1,
+			'term-' . $this->tag_id2,
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
@@ -72,9 +72,9 @@ class Test_Purger extends Pantheon_Integrated_CDN_Testcase {
 			'home',
 			'front',
 			'post-' . $this->post_id1,
-			'archive-user-' . $this->user_id1,
-			'archive-term-' . $this->category_id1,
-			'archive-term-' . $this->tag_id2,
+			'user-' . $this->user_id1,
+			'term-' . $this->category_id1,
+			'term-' . $this->tag_id2,
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
@@ -97,9 +97,9 @@ class Test_Purger extends Pantheon_Integrated_CDN_Testcase {
 			'home',
 			'front',
 			'post-' . $this->post_id1,
-			'archive-user-' . $this->user_id1,
-			'archive-term-' . $this->category_id1,
-			'archive-term-' . $this->tag_id2,
+			'user-' . $this->user_id1,
+			'term-' . $this->category_id1,
+			'term-' . $this->tag_id2,
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
@@ -128,8 +128,8 @@ class Test_Purger extends Pantheon_Integrated_CDN_Testcase {
 			'home',
 			'front',
 			'post-' . $this->page_id2,
-			'archive-user-' . $this->user_id1,
-			'archive-term-' . $this->category_id1,
+			'user-' . $this->user_id1,
+			'term-' . $this->category_id1,
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
@@ -150,7 +150,7 @@ class Test_Purger extends Pantheon_Integrated_CDN_Testcase {
 			'home',
 			'front',
 			'post-' . $this->page_id1,
-			'archive-user-' . $this->user_id1,
+			'user-' . $this->user_id1,
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
@@ -168,7 +168,7 @@ class Test_Purger extends Pantheon_Integrated_CDN_Testcase {
 			'home',
 			'front',
 			'post-' . $this->page_id1,
-			'archive-user-' . $this->user_id1,
+			'user-' . $this->user_id1,
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
@@ -186,7 +186,7 @@ class Test_Purger extends Pantheon_Integrated_CDN_Testcase {
 			'home',
 			'front',
 			'post-' . $this->page_id1,
-			'archive-user-' . $this->user_id1,
+			'user-' . $this->user_id1,
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
@@ -225,7 +225,7 @@ class Test_Purger extends Pantheon_Integrated_CDN_Testcase {
 			'home',
 			'front',
 			'post-' . $this->product_id3,
-			'archive-term-' . $this->product_category_id1,
+			'term-' . $this->product_category_id1,
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
@@ -245,7 +245,7 @@ class Test_Purger extends Pantheon_Integrated_CDN_Testcase {
 			'home',
 			'front',
 			'post-' . $this->product_id2,
-			'archive-term-' . $this->product_category_id1,
+			'term-' . $this->product_category_id1,
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
@@ -264,7 +264,7 @@ class Test_Purger extends Pantheon_Integrated_CDN_Testcase {
 			'home',
 			'front',
 			'post-' . $this->product_id2,
-			'archive-term-' . $this->product_category_id1,
+			'term-' . $this->product_category_id1,
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
@@ -283,7 +283,7 @@ class Test_Purger extends Pantheon_Integrated_CDN_Testcase {
 			'home',
 			'front',
 			'post-' . $this->product_id2,
-			'archive-term-' . $this->product_category_id1,
+			'term-' . $this->product_category_id1,
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
@@ -324,7 +324,7 @@ class Test_Purger extends Pantheon_Integrated_CDN_Testcase {
 			'home',
 			'front',
 			'post-' . $attachment_id,
-			'archive-user-' . $this->user_id1,
+			'user-' . $this->user_id1,
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
@@ -338,8 +338,8 @@ class Test_Purger extends Pantheon_Integrated_CDN_Testcase {
 	public function test_create_term() {
 		$this->tag_id3 = $this->factory->tag->create( array( 'slug' => 'third-tag' ) );
 		$this->assertClearedKeys( array(
-			'archive-term-' . $this->tag_id3,
 			'term-' . $this->tag_id3,
+			'post-term-' . $this->tag_id3,
 		) );
 		// Hasn't appeared on any views yet.
 		$this->assertPurgedURIs( array() );
@@ -353,8 +353,8 @@ class Test_Purger extends Pantheon_Integrated_CDN_Testcase {
 			'description' => 'Test description',
 		) );
 		$this->assertClearedKeys( array(
-			'archive-term-' . $this->tag_id2,
 			'term-' . $this->tag_id2,
+			'post-term-' . $this->tag_id2,
 		) );
 		$this->assertPurgedURIs( array(
 			'/2016/10/14/first-post/',
@@ -368,8 +368,8 @@ class Test_Purger extends Pantheon_Integrated_CDN_Testcase {
 	public function test_delete_term() {
 		wp_delete_term( $this->tag_id2, 'post_tag' );
 		$this->assertClearedKeys( array(
-			'archive-term-' . $this->tag_id2,
 			'term-' . $this->tag_id2,
+			'post-term-' . $this->tag_id2,
 		) );
 		$this->assertPurgedURIs( array(
 			'/2016/10/14/first-post/',
@@ -383,7 +383,7 @@ class Test_Purger extends Pantheon_Integrated_CDN_Testcase {
 	public function test_clean_term_cache() {
 		clean_term_cache( $this->tag_id1 );
 		$this->assertClearedKeys( array(
-			'archive-term-' . $this->tag_id1,
+			'term-' . $this->tag_id1,
 		) );
 		$this->assertPurgedURIs( array(
 			'/tag/first-tag/',
@@ -396,7 +396,7 @@ class Test_Purger extends Pantheon_Integrated_CDN_Testcase {
 	public function test_clean_term_cache_category() {
 		clean_term_cache( $this->category_id1 );
 		$this->assertClearedKeys( array(
-			'archive-term-' . $this->category_id1,
+			'term-' . $this->category_id1,
 		) );
 		$this->assertPurgedURIs( array(
 			'/category/uncategorized/',
@@ -409,7 +409,7 @@ class Test_Purger extends Pantheon_Integrated_CDN_Testcase {
 	public function test_clean_term_cache_product_category() {
 		clean_term_cache( $this->product_category_id1 );
 		$this->assertClearedKeys( array(
-			'archive-term-' . $this->product_category_id1,
+			'term-' . $this->product_category_id1,
 		) );
 		$this->assertPurgedURIs( array(
 			'/product-category/first-product-category/',
@@ -422,7 +422,7 @@ class Test_Purger extends Pantheon_Integrated_CDN_Testcase {
 	public function test_clean_user_cache() {
 		clean_user_cache( $this->user_id1 );
 		$this->assertClearedKeys( array(
-			'archive-user-' . $this->user_id1,
+			'user-' . $this->user_id1,
 		) );
 		$this->assertPurgedURIs( array(
 			'/author/first-user/',


### PR DESCRIPTION
This is a more precise naming strategy.

Also drops `user-<id>` from index views, which is unnecessarily noisy.

See #28